### PR TITLE
Windows Fixes.

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -19,12 +19,16 @@ BUILD_LDFLAGS  = $(LDFLAGS)
 
 SHFLAGS   = -fPIC -ffreestanding
 
-SOFLAGS   = -shared -nostdlib -Wl,--soname=libgrapheme.so.$(VERSION_MAJOR).$(VERSION_MINOR)
 SONAME    = libgrapheme.so.$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)
+SOFLAGS   = -shared -nostdlib -Wl,--soname=$(SONAME)
+ifeq ($(OS),Windows_NT)
+    SONAME = libgrapheme.dll
+    SOFLAGS   = -s -shared -Wl,--subsystem,windows -Wl,--soname=$(SONAME)
+endif
 SOSYMLINK = true
 
 # tools (unset $LDCONFIG to not call ldconfig(1) after install/uninstall)
-CC       = cc
+CC       = gcc
 BUILD_CC = $(CC)
 AR       = ar
 RANLIB   = ranlib

--- a/gen/bidirectional-test.c
+++ b/gen/bidirectional-test.c
@@ -227,7 +227,7 @@ bidirectional_test_list_print(const struct bidirectional_test *test,
 			}
 		}
 		printf(" },\n");
-		printf("\t\t.cplen      = %zu,\n", test[i].cplen);
+		printf("\t\t.cplen      = "PrIU",\n", test[i].cplen);
 
 		printf("\t\t.mode       = (enum "
 		       "grapheme_bidirectional_override[]){");
@@ -248,7 +248,7 @@ bidirectional_test_list_print(const struct bidirectional_test *test,
 			}
 		}
 		printf(" },\n");
-		printf("\t\t.modelen    = %zu,\n", test[i].modelen);
+		printf("\t\t.modelen    = "PrIU",\n", test[i].modelen);
 
 		printf("\t\t.level      = (int_least8_t[]){");
 		for (j = 0; j < test[i].cplen; j++) {
@@ -272,7 +272,7 @@ bidirectional_test_list_print(const struct bidirectional_test *test,
 		} else {
 			printf("NULL,\n");
 		}
-		printf("\t\t.reorderlen = %zu,\n", test[i].reorderlen);
+		printf("\t\t.reorderlen = "PrIU",\n", test[i].reorderlen);
 
 		printf("\t},\n");
 	}

--- a/gen/case.c
+++ b/gen/case.c
@@ -247,7 +247,7 @@ main(int argc, char *argv[])
 			}
 		}
 		printf(" },\n");
-		printf("\t\t.cplen  = %zu,\n", sc[i].upper.cplen);
+		printf("\t\t.cplen  = "PrIU",\n", sc[i].upper.cplen);
 		printf("\t},\n");
 	}
 	printf("};\n\n");
@@ -264,7 +264,7 @@ main(int argc, char *argv[])
 			}
 		}
 		printf(" },\n");
-		printf("\t\t.cplen  = %zu,\n", sc[i].lower.cplen);
+		printf("\t\t.cplen  = "PrIU",\n", sc[i].lower.cplen);
 		printf("\t},\n");
 	}
 	printf("};\n\n");
@@ -281,7 +281,7 @@ main(int argc, char *argv[])
 			}
 		}
 		printf(" },\n");
-		printf("\t\t.cplen  = %zu,\n", sc[i].title.cplen);
+		printf("\t\t.cplen  = "PrIU",\n", sc[i].title.cplen);
 		printf("\t},\n");
 	}
 	printf("};\n\n");

--- a/gen/util.h
+++ b/gen/util.h
@@ -9,6 +9,12 @@
 
 #define LEN(x) (sizeof(x) / sizeof *(x))
 
+#ifdef _WIN32
+#define PrIU "%lu"
+#else
+#define PrIU "%zu"
+#endif
+
 struct property_spec {
 	const char *enumname;
 	const char *file;

--- a/test/bidirectional.c
+++ b/test/bidirectional.c
@@ -46,7 +46,7 @@ main(int argc, char *argv[])
 			continue;
 err:
 			fprintf(stderr,
-			        "%s: Failed conformance test %zu (mode %i) [",
+			        "%s: Failed conformance test "PrIU" (mode %i) [",
 			        argv[0], i, bidirectional_test[i].mode[m]);
 			for (j = 0; j < bidirectional_test[i].cplen; j++) {
 				fprintf(stderr, " 0x%04" PRIXLEAST32,
@@ -66,7 +66,7 @@ err:
 			failed++;
 		}
 	}
-	printf("%s: %zu/%zu conformance tests passed.\n", argv[0],
+	printf("%s: "PrIU"/"PrIU" conformance tests passed.\n", argv[0],
 	       num_tests - failed, num_tests);
 
 	return 0;

--- a/test/case.c
+++ b/test/case.c
@@ -573,8 +573,8 @@ unit_test_callback_is_case_utf8(const void *t, size_t off, const char *name,
 	return 0;
 err:
 	fprintf(stderr,
-	        "%s: %s: Failed unit test %zu \"%s\" "
-	        "(returned (%s, %zu) instead of (%s, %zu)).\n",
+	        "%s: %s: Failed unit test "PrIU" \"%s\" "
+	        "(returned (%s, "PrIU") instead of (%s, "PrIU")).\n",
 	        argv0, name, off, test->description, ret ? "true" : "false",
 	        caselen, test->output.ret ? "true" : "false",
 	        test->output.caselen);
@@ -626,8 +626,8 @@ unit_test_callback_to_case_utf8(const void *t, size_t off, const char *name,
 	return 0;
 err:
 	fprintf(stderr,
-	        "%s: %s: Failed unit test %zu \"%s\" "
-	        "(returned (\"%.*s\", %zu) instead of (\"%.*s\", %zu)).\n",
+	        "%s: %s: Failed unit test "PrIU" \"%s\" "
+	        "(returned (\"%.*s\", "PrIU") instead of (\"%.*s\", "PrIU")).\n",
 	        argv0, name, off, test->description, (int)ret, buf, ret,
 	        (int)test->output.ret, test->output.dest, test->output.ret);
 	return 1;

--- a/test/utf8-decode.c
+++ b/test/utf8-decode.c
@@ -301,14 +301,14 @@ main(int argc, char *argv[])
 
 		if (len != dec_test[i].exp_len || cp != dec_test[i].exp_cp) {
 			fprintf(stderr,
-			        "%s: Failed test %zu: "
+			        "%s: Failed test "PrIU": "
 			        "Expected (%zx,%u), but got (%zx,%u).\n",
 			        argv[0], i, dec_test[i].exp_len,
 			        dec_test[i].exp_cp, len, cp);
 			failed++;
 		}
 	}
-	printf("%s: %zu/%zu unit tests passed.\n", argv[0],
+	printf("%s: "PrIU"/"PrIU" unit tests passed.\n", argv[0],
 	       LEN(dec_test) - failed, LEN(dec_test));
 
 	return (failed > 0) ? 1 : 0;

--- a/test/utf8-encode.c
+++ b/test/utf8-encode.c
@@ -67,7 +67,7 @@ main(int argc, char *argv[])
 		if (len != enc_test[i].exp_len ||
 		    memcmp(arr, enc_test[i].exp_arr, len)) {
 			fprintf(stderr,
-			        "%s, Failed test %zu: "
+			        "%s, Failed test "PrIU": "
 			        "Expected (",
 			        argv[0], i);
 			for (j = 0; j < enc_test[i].exp_len; j++) {
@@ -87,7 +87,7 @@ main(int argc, char *argv[])
 			failed++;
 		}
 	}
-	printf("%s: %zu/%zu unit tests passed.\n", argv[0],
+	printf("%s: "PrIU"/"PrIU" unit tests passed.\n", argv[0],
 	       LEN(enc_test) - failed, LEN(enc_test));
 
 	return (failed > 0) ? 1 : 0;

--- a/test/util.c
+++ b/test/util.c
@@ -24,18 +24,18 @@ run_break_tests(size_t (*next_break)(const uint_least32_t *, size_t),
 			/* check if our resulting offset matches */
 			if (j == test[i].lenlen || res != test[i].len[j++]) {
 				fprintf(stderr,
-				        "%s: Failed conformance test %zu "
+				        "%s: Failed conformance test "PrIU" "
 				        "\"%s\".\n",
 				        argv0, i, test[i].descr);
 				fprintf(stderr,
-				        "J=%zu: EXPECTED len %zu, got %zu\n",
+				        "J="PrIU": EXPECTED len "PrIU", got "PrIU"\n",
 				        j - 1, test[i].len[j - 1], res);
 				failed++;
 				break;
 			}
 		}
 	}
-	printf("%s: %zu/%zu conformance tests passed.\n", argv0,
+	printf("%s: "PrIU"/"PrIU" conformance tests passed.\n", argv0,
 	       testlen - failed, testlen);
 
 	return (failed > 0) ? 1 : 0;
@@ -54,7 +54,7 @@ run_unit_tests(int (*unit_test_callback)(const void *, size_t, const char *,
 			(unit_test_callback(test, i, name, argv0) == 0) ? 0 : 1;
 	}
 
-	printf("%s: %s: %zu/%zu unit tests passed.\n", argv0, name,
+	printf("%s: %s: "PrIU"/"PrIU" unit tests passed.\n", argv0, name,
 	       testlen - failed, testlen);
 
 	return (failed > 0) ? 1 : 0;
@@ -66,7 +66,7 @@ unit_test_callback_next_break(const struct unit_test_next_break *t, size_t off,
                                                    size_t),
                               const char *name, const char *argv0)
 {
-	const struct unit_test_next_break *test = t + off;
+	const struct unit_test_next_break *test = (const struct unit_test_next_break *)(t+off);
 
 	size_t ret = next_break(test->input.src, test->input.srclen);
 
@@ -77,8 +77,8 @@ unit_test_callback_next_break(const struct unit_test_next_break *t, size_t off,
 	return 0;
 err:
 	fprintf(stderr,
-	        "%s: %s: Failed unit test %zu \"%s\" "
-	        "(returned %zu instead of %zu).\n",
+	        "%s: %s: Failed unit test "PrIU" \"%s\" "
+	        "(returned "PrIU" instead of "PrIU").\n",
 	        argv0, name, off, test->description, ret, test->output.ret);
 	return 1;
 }
@@ -101,8 +101,8 @@ unit_test_callback_next_break_utf8(const struct unit_test_next_break_utf8 *t,
 	return 0;
 err:
 	fprintf(stderr,
-	        "%s: %s: Failed unit test %zu \"%s\" "
-	        "(returned %zu instead of %zu).\n",
+	        "%s: %s: Failed unit test "PrIU" \"%s\" "
+	        "(returned "PrIU" instead of "PrIU").\n",
 	        argv0, name, off, test->description, ret, test->output.ret);
 	return 1;
 }

--- a/test/util.h
+++ b/test/util.h
@@ -10,6 +10,13 @@
 #undef LEN
 #define LEN(x) (sizeof(x) / sizeof(*(x)))
 
+#undef PrIU
+#ifdef _WIN32
+#define PrIU "%lu"
+#else
+#define PrIU "%zu"
+#endif
+
 struct unit_test_next_break {
 	const char *description;
 


### PR DESCRIPTION
I was trying to find a Grapheme Break detection function for Windows, as I was
unable to build `libunistring` correctly. I found your library very helpful.

I was able to get this working thanks to [this StackOverflow post](https://stackoverflow.com/questions/735126/are-there-alternate-implementations-of-gnu-getline-interface) and some tweaking of `config.mk`. I've kept this as a reference pull-request so that anyone who runs into the same issues I do, can give this a try.